### PR TITLE
Fix argument for SplitEnvironmentForStaticHosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Usage:
   aas-core3.0-sk-split-environment-for-static-hosting [options]
 
 Options:
-  --environments <environments> (REQUIRED)  
+  --environment <environment> (REQUIRED)
   Path to the AAS environment serialized as a JSON file to be split into different files 
   for static hosting
   --output-dir <output-dir> (REQUIRED)      

--- a/src/SplitEnvironmentForStaticHosting/Program.cs
+++ b/src/SplitEnvironmentForStaticHosting/Program.cs
@@ -300,7 +300,7 @@ namespace SplitEnvironmentForStaticHosting
             var environmentOption = new System.CommandLine.Option<
                 string
             >(
-                name: "--environments",
+                name: "--environment",
                 description:
                 "Path to the AAS environment serialized as a JSON file " +
                 "to be split into different files for static hosting"


### PR DESCRIPTION
We got the `--environments` argument wrong as it should be a singular, not a plural.