### PR TITLE
Update to aas-core3.0-csharp 1.0.2

### DIFF
--- a/src/CommonOutputting/CommonOutputting.csproj
+++ b/src/CommonOutputting/CommonOutputting.csproj
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
     </ItemGroup>
     
 </Project>

--- a/src/CsvEnhancing/CsvEnhancing.csproj
+++ b/src/CsvEnhancing/CsvEnhancing.csproj
@@ -9,6 +9,6 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
     </ItemGroup>
 </Project>

--- a/src/EnvironmentFromCsvConceptDescriptions/EnvironmentFromCsvConceptDescriptions.csproj
+++ b/src/EnvironmentFromCsvConceptDescriptions/EnvironmentFromCsvConceptDescriptions.csproj
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/src/EnvironmentFromCsvShellsAndSubmodels/EnvironmentFromCsvShellsAndSubmodels.csproj
+++ b/src/EnvironmentFromCsvShellsAndSubmodels/EnvironmentFromCsvShellsAndSubmodels.csproj
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-      <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+      <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
       <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/src/ListDanglingModelReferences/ListDanglingModelReferences.csproj
+++ b/src/ListDanglingModelReferences/ListDanglingModelReferences.csproj
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 </Project>

--- a/src/MergeEnvironments/MergeEnvironments.csproj
+++ b/src/MergeEnvironments/MergeEnvironments.csproj
@@ -28,7 +28,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/src/Registering/Registering.csproj
+++ b/src/Registering/Registering.csproj
@@ -7,7 +7,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
     </ItemGroup>
 
 </Project>

--- a/src/SplitEnvironmentForStaticHosting/SplitEnvironmentForStaticHosting.csproj
+++ b/src/SplitEnvironmentForStaticHosting/SplitEnvironmentForStaticHosting.csproj
@@ -28,7 +28,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
     

--- a/src/TreeShakeConceptDescriptions/TreeShakeConceptDescriptions.csproj
+++ b/src/TreeShakeConceptDescriptions/TreeShakeConceptDescriptions.csproj
@@ -27,7 +27,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 

--- a/src/Verify/Verify.csproj
+++ b/src/Verify/Verify.csproj
@@ -27,7 +27,7 @@
     </PropertyGroup>
     
     <ItemGroup>
-        <PackageReference Include="AasCore.Aas3_0" Version="1.0.0-rc2" />
+        <PackageReference Include="AasCore.Aas3_0" Version="1.0.2" />
         <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
     </ItemGroup>
 </Project>


### PR DESCRIPTION
We update to the latest stable release of aas-core3.0-csharp to catch up with the updates in the verification.