### PR TITLE
Release 1.0.0-rc2

### DIFF
--- a/src/EnvironmentFromCsvConceptDescriptions/EnvironmentFromCsvConceptDescriptions.csproj
+++ b/src/EnvironmentFromCsvConceptDescriptions/EnvironmentFromCsvConceptDescriptions.csproj
@@ -9,7 +9,7 @@
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <Version>1.0.0-rc1</Version>
+        <Version>1.0.0-rc2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/EnvironmentFromCsvShellsAndSubmodels/EnvironmentFromCsvShellsAndSubmodels.csproj
+++ b/src/EnvironmentFromCsvShellsAndSubmodels/EnvironmentFromCsvShellsAndSubmodels.csproj
@@ -9,7 +9,7 @@
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <Version>1.0.0-rc1</Version>
+        <Version>1.0.0-rc2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/ListDanglingModelReferences/ListDanglingModelReferences.csproj
+++ b/src/ListDanglingModelReferences/ListDanglingModelReferences.csproj
@@ -9,7 +9,7 @@
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <Version>1.0.0-rc1</Version>
+        <Version>1.0.0-rc2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/MergeEnvironments/MergeEnvironments.csproj
+++ b/src/MergeEnvironments/MergeEnvironments.csproj
@@ -10,7 +10,7 @@
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <Version>1.0.0-rc1</Version>
+        <Version>1.0.0-rc2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/SplitEnvironmentForStaticHosting/SplitEnvironmentForStaticHosting.csproj
+++ b/src/SplitEnvironmentForStaticHosting/SplitEnvironmentForStaticHosting.csproj
@@ -10,7 +10,7 @@
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <Version>1.0.0-rc1</Version>
+        <Version>1.0.0-rc2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/TreeShakeConceptDescriptions/TreeShakeConceptDescriptions.csproj
+++ b/src/TreeShakeConceptDescriptions/TreeShakeConceptDescriptions.csproj
@@ -9,7 +9,7 @@
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <Version>1.0.0-rc1</Version>
+        <Version>1.0.0-rc2</Version>
     </PropertyGroup>
 
     <PropertyGroup>

--- a/src/Verify/Verify.csproj
+++ b/src/Verify/Verify.csproj
@@ -9,7 +9,7 @@
         <SelfContained>true</SelfContained>
         <RuntimeIdentifier>win-x64</RuntimeIdentifier>
 
-        <Version>1.0.0-rc1</Version>
+        <Version>1.0.0-rc2</Version>
     </PropertyGroup>
 
     <PropertyGroup>


### PR DESCRIPTION
* Update to aas-core3.0-csharp 1.0.2 (#6)

  We update to the latest stable release of aas-core3.0-csharp to catch up with the updates in the verification.